### PR TITLE
fix(core): RFC-0008 column pinning state wiring (ACG-11)

### DIFF
--- a/.spec/rfc/ISSUE_REGISTRY.md
+++ b/.spec/rfc/ISSUE_REGISTRY.md
@@ -1,6 +1,6 @@
 # RFC → Multica Issue Registry
 
-> **Generated**: 2026-06-29
+> **Generated**: 2026-06-29 · **Synced**: 2026-07-26 (Multica pipeline)
 > **Parent**: [ACG-2](mention://issue/b7f108c7-583f-4986-9f38-a30cec79d5a0)
 
 Each RFC maps to one implementation issue. Promote `backlog` → `todo` when starting work.
@@ -14,7 +14,7 @@ Each RFC maps to one implementation issue. Promote `backlog` → `todo` when sta
 | 0005 | Virtual scrolling | [ACG-8](mention://issue/0d1a757b-d482-41bf-be12-7a92dfd585f1) | done | 3 |
 | 0006 | Pagination | [ACG-9](mention://issue/49ce20a9-b580-4471-a70c-128ea821ae81) | done | 3 |
 | 0007 | Row selection | [ACG-10](mention://issue/7eb0775c-99ad-49c6-92c6-8b38dbe3cd0a) | done | 3 |
-| 0008 | Column pinning | [ACG-11](mention://issue/22a51744-a4f7-4b4c-b941-b31176bbc816) | backlog | 4 |
+| 0008 | Column pinning | [ACG-11](mention://issue/22a51744-a4f7-4b4c-b941-b31176bbc816) | in_progress | 4 |
 | 0009 | Cell editing | [ACG-12](mention://issue/14e4823f-7cda-4988-882f-ae6f9cdab6a2) | backlog | 4 |
 | 0010 | Grouping and aggregation | [ACG-21](mention://issue/6d6679b3-e34d-41fa-a479-788382658423) | backlog | 7 |
 | 0011 | Theme system advanced | [ACG-14](mention://issue/2d130de1-2c23-44f5-a391-d827eea5702a) | backlog | 5 |

--- a/packages/core/src/components/Grid.wsx
+++ b/packages/core/src/components/Grid.wsx
@@ -838,6 +838,11 @@ export class Grid extends LightComponent {
                 ? computeTotalPages(paginationTotalRows, this.pagination.pageSize)
                 : undefined;
         const isSelectionEnabled = this._selectionConfigIsSet ? this._selectionConfig?.enabled !== false : false;
+        const isPinningEnabled = this._pinningConfigIsSet ? this._pinningConfig?.enabled !== false : false;
+        const hasPinnedColumns =
+            (this.columnPinning.left?.length ?? 0) > 0 ||
+            (this.columnPinning.right?.length ?? 0) > 0;
+        const shouldEnableColumnPinning = isPinningEnabled || hasPinnedColumns;
         const isEditingEnabled = this._editingConfigIsSet ? this._editingConfig?.enabled !== false : false;
         const isGroupingEnabled = this._groupingConfigIsSet ? this._groupingConfig?.enabled !== false : false;
 
@@ -935,7 +940,7 @@ export class Grid extends LightComponent {
                     grouping: this.grouping,
                     expanded: this.expanded === false ? {} : this.expanded,
                 }),
-                columnPinning: { left: [], right: [] },
+                columnPinning: this.columnPinning,
                 columnSizing: currentColumnSizing,
                 columnSizingInfo: this.columnSizingInfo ?? DEFAULT_COLUMN_SIZING_INFO,
                 pagination: this.pagination,
@@ -996,6 +1001,18 @@ export class Grid extends LightComponent {
                     this.notifySelectionChange();
                     this.updateTable();
                 }
+            }),
+            ...(shouldEnableColumnPinning && {
+                enableColumnPinning: true,
+                onColumnPinningChange: (updater: any) => {
+                    const next =
+                        typeof updater === "function"
+                            ? updater(this.columnPinning)
+                            : updater;
+                    this.columnPinning = next;
+                    this._pinningConfig?.onPinningChange?.(next);
+                    this.updateTable();
+                },
             }),
             onColumnOrderChange: (updater) => {
                 const newOrder =

--- a/packages/core/src/utils/create-grid.ts
+++ b/packages/core/src/utils/create-grid.ts
@@ -13,6 +13,7 @@ import type { GridResizingConfig } from "../types/resizing";
 import type { GridVirtualizationConfig } from "../types/virtualization";
 import type { GridSelectionConfig } from "../types/selection";
 import type { GridPaginationConfig } from "../types/pagination";
+import type { GridPinningConfig } from "../types/pinning";
 
 export interface CreateGridOptions<TData extends { userId?: string }> {
     /**
@@ -51,6 +52,10 @@ export interface CreateGridOptions<TData extends { userId?: string }> {
      * 分页配置（RFC-0006）
      */
     pagination?: GridPaginationConfig;
+    /**
+     * 列固定配置（RFC-0008）
+     */
+    pinning?: GridPinningConfig;
     /**
      * 容器元素（可选，如果不提供则返回元素本身）
      */
@@ -96,6 +101,7 @@ export function createGrid<TData extends { userId?: string }>(
         virtualization,
         selection,
         pagination,
+        pinning,
         container,
     } = options;
 
@@ -130,6 +136,10 @@ export function createGrid<TData extends { userId?: string }>(
 
     if (pagination) {
         gridElement.paginationConfig = pagination;
+    }
+
+    if (pinning) {
+        gridElement.pinningConfig = pinning;
     }
 
     gridElement.columns = columns;

--- a/packages/core/test/pinning.test.ts
+++ b/packages/core/test/pinning.test.ts
@@ -1,0 +1,130 @@
+/// <reference types="vitest" />
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import "../src/components/Grid.wsx";
+import { waitFor } from "@testing-library/dom";
+import { createGrid } from "../src/utils/create-grid";
+
+type PinningGrid = HTMLElement & {
+    data: unknown[];
+    columns: unknown[];
+    pinningConfig: {
+        enabled: boolean;
+        initialState?: { left?: string[]; right?: string[] };
+        onPinningChange?: (pinning: { left?: string[]; right?: string[] }) => void;
+    };
+    pinColumn: (columnId: string, position: "left" | "right" | false) => void;
+    unpinColumn: (columnId: string) => void;
+    getPinnedColumns: () => { left: string[]; right: string[] };
+};
+
+function mountPinningGrid(container: HTMLElement): PinningGrid {
+    const grid = document.createElement("wsx-ac-grid") as PinningGrid;
+    grid.data = [
+        { userId: "1", name: "Alice", age: 30, status: "active" },
+        { userId: "2", name: "Bob", age: 25, status: "inactive" },
+    ];
+    grid.columns = [
+        { id: "name", accessorKey: "name", header: "Name", size: 150 },
+        { id: "age", accessorKey: "age", header: "Age", size: 100 },
+        { id: "status", accessorKey: "status", header: "Status", size: 120 },
+    ];
+    container.appendChild(grid);
+    return grid;
+}
+
+describe("Grid Column Pinning (RFC-0008)", () => {
+    let container: HTMLElement;
+
+    beforeEach(() => {
+        container = document.createElement("div");
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+        container.innerHTML = "";
+    });
+
+    it("applies initial pinning state from pinningConfig", async () => {
+        const grid = mountPinningGrid(container);
+        grid.pinningConfig = {
+            enabled: true,
+            initialState: { left: ["name"], right: ["status"] },
+        };
+
+        await waitFor(() => {
+            const pinned = grid.getPinnedColumns();
+            expect(pinned.left).toEqual(["name"]);
+            expect(pinned.right).toEqual(["status"]);
+        });
+    });
+
+    it("pins and unpins columns via public API", async () => {
+        const grid = mountPinningGrid(container);
+        grid.pinningConfig = { enabled: true };
+
+        await waitFor(() => expect(grid.getPinnedColumns).toBeDefined());
+
+        grid.pinColumn("name", "left");
+        grid.pinColumn("status", "right");
+
+        await waitFor(() => {
+            const pinned = grid.getPinnedColumns();
+            expect(pinned.left).toContain("name");
+            expect(pinned.right).toContain("status");
+        });
+
+        grid.unpinColumn("name");
+        await waitFor(() => {
+            expect(grid.getPinnedColumns().left).not.toContain("name");
+        });
+    });
+
+    it("renders data-pinned on pinned header cells", async () => {
+        const grid = mountPinningGrid(container);
+        grid.pinningConfig = {
+            enabled: true,
+            initialState: { left: ["name"] },
+        };
+
+        await waitFor(() => {
+            const root = grid.shadowRoot ?? grid;
+            const pinnedHeader = root.querySelector(
+                '.grid-header-cell[data-pinned="left"]',
+            );
+            expect(pinnedHeader).toBeTruthy();
+            expect(pinnedHeader?.getAttribute("data-column-id")).toBe("name");
+        });
+    });
+
+    it("notifies onPinningChange when pinning updates", async () => {
+        const onPinningChange = vi.fn();
+        const grid = mountPinningGrid(container);
+        grid.pinningConfig = { enabled: true, onPinningChange };
+
+        await waitFor(() => expect(grid.pinColumn).toBeDefined());
+        grid.pinColumn("age", "left");
+
+        await waitFor(() => {
+            expect(onPinningChange).toHaveBeenCalled();
+            const lastCall = onPinningChange.mock.calls.at(-1)?.[0];
+            expect(lastCall.left).toContain("age");
+        });
+    });
+
+    it("wires pinning through createGrid", async () => {
+        const grid = createGrid({
+            data: [{ userId: "1", name: "Test" }],
+            columns: [{ id: "name", accessorKey: "name", header: "Name" }],
+            pinning: {
+                enabled: true,
+                initialState: { left: ["name"] },
+            },
+            container,
+        }) as PinningGrid;
+
+        await waitFor(() => {
+            expect(grid.getPinnedColumns().left).toEqual(["name"]);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Fix **RFC-0008** column pinning: TanStack `createTable` was hardcoding `columnPinning: { left: [], right: [] }`, so `pinningConfig.initialState` and `pinColumn()` had no effect
- Enable `enableColumnPinning` + `onColumnPinningChange` when pinning is configured or columns are pinned
- Add `createGrid({ pinning })` and **5** integration tests (`pinning.test.ts`)

Closes ACG-11 (partial — core pinning path; RFC completion doc move follow-up).

## Test plan

- [x] `pnpm --filter @ac-grid/core exec vitest run` → **114/114**
- [x] `test/pinning.test.ts` — initialState, pin/unpin API, DOM `data-pinned`, onPinningChange, createGrid
- [ ] Manual: demo-react with `pinningConfig` — scroll horizontally, left/right columns stay visible

## Known gaps (follow-up)

- Move RFC to `completed/` + parity matrix after review
- Pinned column drag reorder, visual border polish per RFC-0008 phase 2

Made with [Cursor](https://cursor.com)